### PR TITLE
Add planetary aspects, birth charts, predictions, CPU affinity, exten…

### DIFF
--- a/src/astrology/aspects.rs
+++ b/src/astrology/aspects.rs
@@ -1,0 +1,319 @@
+use super::planets::{Planet, PlanetaryPosition};
+
+/// The classical astrological aspects (angular relationships between planets)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AspectType {
+    Conjunction,  // 0°   — planets merge energies
+    Opposition,   // 180° — planets in tension
+    Trine,        // 120° — harmonious flow
+    Square,       // 90°  — dynamic challenge
+    Sextile,      // 60°  — opportunity
+    Quincunx,     // 150° — adjustment required
+}
+
+/// Whether an aspect is beneficial, challenging, or neutral for scheduling
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AspectNature {
+    Harmonious,
+    Challenging,
+    Neutral,
+}
+
+/// A detected angular relationship between two planets
+#[derive(Debug, Clone)]
+pub struct Aspect {
+    pub planet_a: Planet,
+    pub planet_b: Planet,
+    pub aspect_type: AspectType,
+    pub nature: AspectNature,
+    pub orb: f64,       // degrees off from the exact aspect angle
+    pub strength: f64,  // 1.0 = exact, approaches 0.0 at the edge of the orb
+}
+
+impl AspectType {
+    pub fn target_angle(self) -> f64 {
+        match self {
+            AspectType::Conjunction => 0.0,
+            AspectType::Opposition  => 180.0,
+            AspectType::Trine       => 120.0,
+            AspectType::Square      => 90.0,
+            AspectType::Sextile     => 60.0,
+            AspectType::Quincunx    => 150.0,
+        }
+    }
+
+    pub fn max_orb(self) -> f64 {
+        match self {
+            AspectType::Conjunction |
+            AspectType::Opposition  |
+            AspectType::Trine       |
+            AspectType::Square      => 8.0,
+            AspectType::Sextile     => 6.0,
+            AspectType::Quincunx    => 3.0,
+        }
+    }
+
+    // Conjunction is context-dependent — treated Neutral
+    pub fn nature(self) -> AspectNature {
+        match self {
+            AspectType::Trine | AspectType::Sextile                  => AspectNature::Harmonious,
+            AspectType::Square | AspectType::Opposition |
+            AspectType::Quincunx                                     => AspectNature::Challenging,
+            AspectType::Conjunction                                   => AspectNature::Neutral,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            AspectType::Conjunction => "Conjunction",
+            AspectType::Opposition  => "Opposition",
+            AspectType::Trine       => "Trine",
+            AspectType::Square      => "Square",
+            AspectType::Sextile     => "Sextile",
+            AspectType::Quincunx    => "Quincunx",
+        }
+    }
+
+    pub fn symbol(self) -> &'static str {
+        match self {
+            AspectType::Conjunction => "☌",
+            AspectType::Opposition  => "☍",
+            AspectType::Trine       => "△",
+            AspectType::Square      => "□",
+            AspectType::Sextile     => "⚹",
+            AspectType::Quincunx    => "⚻",
+        }
+    }
+
+    /// Scheduling priority multiplier when this aspect involves a task's ruling planet
+    pub fn scheduling_modifier(self) -> f64 {
+        match self {
+            AspectType::Trine       => 1.4,
+            AspectType::Conjunction => 1.3,
+            AspectType::Sextile     => 1.2,
+            AspectType::Quincunx    => 0.8,
+            AspectType::Square      => 0.7,
+            AspectType::Opposition  => 0.6,
+        }
+    }
+}
+
+/// Compute the smallest angular separation between two ecliptic longitudes (0–180°)
+fn angular_separation(lon_a: f64, lon_b: f64) -> f64 {
+    let diff = (lon_b - lon_a).rem_euclid(360.0);
+    if diff <= 180.0 { diff } else { 360.0 - diff }
+}
+
+/// Detect all aspects between all pairs of planets in `positions`.
+/// When a separation matches multiple aspect types, only the closest match is kept.
+pub fn calculate_aspects(positions: &[PlanetaryPosition]) -> Vec<Aspect> {
+    let all_types = [
+        AspectType::Conjunction,
+        AspectType::Opposition,
+        AspectType::Trine,
+        AspectType::Square,
+        AspectType::Sextile,
+        AspectType::Quincunx,
+    ];
+
+    let mut aspects = Vec::new();
+
+    for i in 0..positions.len() {
+        for j in (i + 1)..positions.len() {
+            let pa = &positions[i];
+            let pb = &positions[j];
+
+            let sep = angular_separation(pa.longitude, pb.longitude);
+
+            // Find the tightest matching aspect type
+            let best = all_types.iter().filter_map(|&asp| {
+                let orb = (sep - asp.target_angle()).abs();
+                if orb <= asp.max_orb() {
+                    Some((asp, orb))
+                } else {
+                    None
+                }
+            }).min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+            if let Some((asp_type, orb)) = best {
+                let strength = 1.0 - (orb / asp_type.max_orb());
+                aspects.push(Aspect {
+                    planet_a:    pa.planet,
+                    planet_b:    pb.planet,
+                    aspect_type: asp_type,
+                    nature:      asp_type.nature(),
+                    orb,
+                    strength,
+                });
+            }
+        }
+    }
+
+    aspects
+}
+
+/// Return all aspects that involve `planet` (either as planet_a or planet_b)
+pub fn aspects_for_planet<'a>(aspects: &'a [Aspect], planet: Planet) -> Vec<&'a Aspect> {
+    aspects.iter()
+        .filter(|a| a.planet_a == planet || a.planet_b == planet)
+        .collect()
+}
+
+/// Combine all aspect modifiers for a planet into a single scheduling multiplier.
+/// Harmonious aspects stack multiplicatively as boosts; challenging ones as penalties.
+/// Result is clamped to [0.3, 2.0].
+pub fn combined_aspect_modifier(aspects: &[Aspect], planet: Planet) -> f64 {
+    let relevant = aspects_for_planet(aspects, planet);
+    if relevant.is_empty() {
+        return 1.0;
+    }
+
+    let modifier = relevant.iter().fold(1.0_f64, |acc, asp| {
+        // Weight the modifier by the aspect's strength (exact = full effect)
+        let raw = asp.aspect_type.scheduling_modifier();
+        let weighted = 1.0 + (raw - 1.0) * asp.strength;
+        acc * weighted
+    });
+
+    modifier.clamp(0.3, 2.0)
+}
+
+/// Generate human-readable flavor text describing how aspects affect a planet's domain
+pub fn describe_aspects(aspects: &[Aspect], planet: Planet) -> String {
+    let relevant = aspects_for_planet(aspects, planet);
+
+    if relevant.is_empty() {
+        return format!(
+            "{} stands alone in the cosmos — unaspected, operating on pure instinct",
+            planet.name()
+        );
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+
+    for asp in &relevant {
+        let other = if asp.planet_a == planet { asp.planet_b } else { asp.planet_a };
+        let (emoji, flavor) = match asp.aspect_type {
+            AspectType::Trine => (
+                "✨",
+                format!("{} {} {} {} — cosmic harmony flows freely!", planet.name(), asp.aspect_type.symbol(), other.name(), asp.aspect_type.name()),
+            ),
+            AspectType::Sextile => (
+                "🌟",
+                format!("{} {} {} {} — opportunity knocks from the stars!", planet.name(), asp.aspect_type.symbol(), other.name(), asp.aspect_type.name()),
+            ),
+            AspectType::Conjunction => (
+                "☄️",
+                format!("{} {} {} {} — energies merge in cosmic union!", planet.name(), asp.aspect_type.symbol(), other.name(), asp.aspect_type.name()),
+            ),
+            AspectType::Opposition => (
+                "⚠️",
+                format!("{} {} {} {} — cosmic tension! Opposing forces clash!", planet.name(), asp.aspect_type.symbol(), other.name(), asp.aspect_type.name()),
+            ),
+            AspectType::Square => (
+                "⚔️",
+                format!("{} {} {} {} — dynamic friction creates challenges!", planet.name(), asp.aspect_type.symbol(), other.name(), asp.aspect_type.name()),
+            ),
+            AspectType::Quincunx => (
+                "🌀",
+                format!("{} {} {} {} — adjustment needed, stars misaligned!", planet.name(), asp.aspect_type.symbol(), other.name(), asp.aspect_type.name()),
+            ),
+        };
+        parts.push(format!("{} {}", emoji, flavor));
+    }
+
+    parts.join(" | ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::astrology::planets::{ZodiacSign, MoonPhase};
+
+    fn make_pos(planet: Planet, longitude: f64) -> PlanetaryPosition {
+        PlanetaryPosition {
+            planet,
+            longitude,
+            sign: ZodiacSign::from_longitude(longitude, false),
+            retrograde: false,
+            moon_phase: if planet == Planet::Moon { Some(MoonPhase::from_angle(longitude)) } else { None },
+        }
+    }
+
+    #[test]
+    fn test_opposition_detection() {
+        // Exact opposition
+        let aspects = calculate_aspects(&[make_pos(Planet::Sun, 0.0), make_pos(Planet::Moon, 180.0)]);
+        assert_eq!(aspects.len(), 1);
+        assert_eq!(aspects[0].aspect_type, AspectType::Opposition);
+        assert!((aspects[0].orb).abs() < 0.01);
+
+        // Within orb (5° off)
+        let aspects = calculate_aspects(&[make_pos(Planet::Sun, 0.0), make_pos(Planet::Moon, 175.0)]);
+        assert_eq!(aspects[0].aspect_type, AspectType::Opposition);
+
+        // Outside orb (10° off — greater than 8°)
+        let aspects = calculate_aspects(&[make_pos(Planet::Sun, 0.0), make_pos(Planet::Moon, 170.0)]);
+        assert!(aspects.iter().all(|a| a.aspect_type != AspectType::Opposition));
+    }
+
+    #[test]
+    fn test_trine_detection() {
+        // Exact trine
+        let aspects = calculate_aspects(&[make_pos(Planet::Mars, 0.0), make_pos(Planet::Jupiter, 120.0)]);
+        assert_eq!(aspects[0].aspect_type, AspectType::Trine);
+
+        // Trine wrapping around 0°: 350° and 110° → 120° separation
+        let aspects = calculate_aspects(&[make_pos(Planet::Saturn, 350.0), make_pos(Planet::Mercury, 110.0)]);
+        assert!(aspects.iter().any(|a| a.aspect_type == AspectType::Trine), "Expected trine across 0°");
+    }
+
+    #[test]
+    fn test_conjunction_detection() {
+        // Exact conjunction
+        let aspects = calculate_aspects(&[make_pos(Planet::Venus, 45.0), make_pos(Planet::Mars, 45.0)]);
+        assert_eq!(aspects[0].aspect_type, AspectType::Conjunction);
+
+        // Conjunction across 0°: 358° and 2° → 4° separation
+        let aspects = calculate_aspects(&[make_pos(Planet::Sun, 358.0), make_pos(Planet::Moon, 2.0)]);
+        assert!(aspects.iter().any(|a| a.aspect_type == AspectType::Conjunction), "Expected conjunction across 0°");
+    }
+
+    #[test]
+    fn test_no_aspects_edge_cases() {
+        assert!(calculate_aspects(&[]).is_empty());
+        assert!(calculate_aspects(&[make_pos(Planet::Sun, 90.0)]).is_empty());
+    }
+
+    #[test]
+    fn test_combined_modifier_clamped() {
+        // Stack many aspects — result must stay within [0.3, 2.0]
+        let positions = vec![
+            make_pos(Planet::Sun,     0.0),
+            make_pos(Planet::Moon,    120.0), // Trine
+            make_pos(Planet::Mercury, 60.0),  // Sextile
+            make_pos(Planet::Mars,    180.0), // Opposition
+            make_pos(Planet::Jupiter, 90.0),  // Square
+        ];
+        let aspects = calculate_aspects(&positions);
+        let modifier = combined_aspect_modifier(&aspects, Planet::Sun);
+        assert!(modifier >= 0.3 && modifier <= 2.0, "modifier {modifier} out of range");
+        assert!((combined_aspect_modifier(&[], Planet::Sun) - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_aspect_natures() {
+        assert_eq!(AspectType::Trine.nature(), AspectNature::Harmonious);
+        assert_eq!(AspectType::Sextile.nature(), AspectNature::Harmonious);
+        assert_eq!(AspectType::Square.nature(), AspectNature::Challenging);
+        assert_eq!(AspectType::Opposition.nature(), AspectNature::Challenging);
+        assert_eq!(AspectType::Quincunx.nature(), AspectNature::Challenging);
+        assert_eq!(AspectType::Conjunction.nature(), AspectNature::Neutral);
+    }
+
+    #[test]
+    fn test_describe_unaspected() {
+        let desc = describe_aspects(&[], Planet::Mercury);
+        assert!(desc.contains("unaspected") || desc.contains("alone"));
+    }
+}

--- a/src/astrology/birth_chart.rs
+++ b/src/astrology/birth_chart.rs
@@ -1,0 +1,271 @@
+use std::collections::HashMap;
+use std::path::Path;
+use chrono::{DateTime, Duration, Utc};
+
+use super::planets::{
+    calculate_planetary_positions_with_zodiac, Element, MoonPhase, Planet,
+    PlanetaryPosition, ZodiacSign,
+};
+use super::tasks::TaskType;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ProcessBirthChart
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The natal (birth) astrological chart for a running process.
+#[derive(Debug, Clone)]
+pub struct ProcessBirthChart {
+    pub pid: i32,
+    pub birth_time: DateTime<Utc>,
+    pub natal_positions: Vec<PlanetaryPosition>,
+    pub sun_sign: ZodiacSign,
+    pub ascendant_element: Element,
+    pub natal_moon_phase: MoonPhase,
+}
+
+impl ProcessBirthChart {
+    /// Build a birth chart by reading `/proc/<pid>/stat`.
+    /// Returns `None` if the process does not exist or its start time cannot
+    /// be determined.
+    pub fn from_pid(pid: i32, use_13_signs: bool) -> Option<Self> {
+        let birth_time = read_process_birth_time(pid)?;
+        let natal_positions =
+            calculate_planetary_positions_with_zodiac(birth_time, use_13_signs);
+
+        let sun_sign = natal_positions
+            .iter()
+            .find(|p| p.planet == Planet::Sun)
+            .map(|p| p.sign)?;
+
+        let ascendant_element = sun_sign.element();
+
+        let natal_moon_phase = natal_positions
+            .iter()
+            .find(|p| p.planet == Planet::Moon)
+            .and_then(|p| p.moon_phase)
+            .unwrap_or(MoonPhase::NewMoon);
+
+        Some(Self {
+            pid,
+            birth_time,
+            natal_positions,
+            sun_sign,
+            ascendant_element,
+            natal_moon_phase,
+        })
+    }
+
+    pub fn natal_sign_for_planet(&self, planet: Planet) -> Option<ZodiacSign> {
+        self.natal_positions
+            .iter()
+            .find(|p| p.planet == planet)
+            .map(|p| p.sign)
+    }
+
+    /// Compare natal chart against current planetary positions for the ruling
+    /// planet of the given task type. Returns a scheduling multiplier:
+    /// same element = 1.3, compatible = 1.1, neutral = 1.0, opposing = 0.8
+    pub fn compatibility_with_current(
+        &self,
+        current_positions: &[PlanetaryPosition],
+        task_type: TaskType,
+    ) -> f64 {
+        let ruling_planet = task_type.ruling_planet();
+
+        let natal_element = self
+            .natal_positions
+            .iter()
+            .find(|p| p.planet == ruling_planet)
+            .map(|p| p.sign.element());
+
+        let current_element = current_positions
+            .iter()
+            .find(|p| p.planet == ruling_planet)
+            .map(|p| p.sign.element());
+
+        match (natal_element, current_element) {
+            (Some(natal), Some(current)) => element_compatibility(natal, current),
+            _ => 1.0,
+        }
+    }
+
+    pub fn describe_natal_chart(&self) -> String {
+        let destiny = match self.ascendant_element {
+            Element::Fire  => "blazing computational glory",
+            Element::Earth => "steadfast, long-running endurance",
+            Element::Air   => "swift network communication",
+            Element::Water => "deep memory exploration",
+        };
+
+        format!(
+            "🌟 Born under {} with Moon in {}! A {} spirit destined for {}!",
+            self.sun_sign.name(),
+            self.natal_moon_phase.name(),
+            self.ascendant_element.name(),
+            destiny,
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ProcessRegistry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A cache of birth charts for currently running processes.
+pub struct ProcessRegistry {
+    charts: HashMap<i32, ProcessBirthChart>,
+    use_13_signs: bool,
+}
+
+impl ProcessRegistry {
+    pub fn new(use_13_signs: bool) -> Self {
+        Self {
+            charts: HashMap::new(),
+            use_13_signs,
+        }
+    }
+
+    /// Get or lazily create the birth chart for a process.
+    pub fn get_or_create(&mut self, pid: i32) -> Option<&ProcessBirthChart> {
+        if !self.charts.contains_key(&pid) {
+            let chart = ProcessBirthChart::from_pid(pid, self.use_13_signs)?;
+            self.charts.insert(pid, chart);
+        }
+        self.charts.get(&pid)
+    }
+
+    pub fn evict_dead_processes(&mut self) {
+        self.charts
+            .retain(|&pid, _| Path::new(&format!("/proc/{pid}")).exists());
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn read_process_birth_time(pid: i32) -> Option<DateTime<Utc>> {
+    let path = format!("/proc/{pid}/stat");
+    let content = std::fs::read_to_string(&path).ok()?;
+
+    // The comm field (field 2) can contain spaces and is wrapped in parentheses.
+    // Find the closing ')' to safely skip it before splitting the rest.
+    let after_comm = content.find(')').map(|i| &content[i + 1..])?;
+    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+
+    // field 22 (1-indexed in /proc/pid/stat) = fields[19] in our after_comm slice
+    let starttime: u64 = fields.get(19)?.parse().ok()?;
+
+    let ticks_per_sec = procfs::ticks_per_second();
+    let start_secs_since_boot = starttime / ticks_per_sec;
+    let start_subsec_ticks   = starttime % ticks_per_sec;
+    let start_nanos = (start_subsec_ticks * 1_000_000_000) / ticks_per_sec;
+
+    let boot_time: DateTime<Utc> = procfs::boot_time().ok()?.into();
+
+    let elapsed = Duration::seconds(start_secs_since_boot as i64)
+        + Duration::nanoseconds(start_nanos as i64);
+
+    Some(boot_time + elapsed)
+}
+
+fn element_compatibility(natal: Element, current: Element) -> f64 {
+    if natal == current {
+        return 1.3;
+    }
+
+    match (natal, current) {
+        // Compatible pairs: Fire/Air (both active/upward) and Earth/Water (both receptive)
+        (Element::Fire, Element::Air) | (Element::Air, Element::Fire)    => 1.1,
+        (Element::Earth, Element::Water) | (Element::Water, Element::Earth) => 1.1,
+        // Opposing pairs
+        (Element::Fire, Element::Water) | (Element::Water, Element::Fire)   => 0.8,
+        (Element::Earth, Element::Air)  | (Element::Air, Element::Earth)    => 0.8,
+        _ => 1.0,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_position(planet: Planet, sign: ZodiacSign) -> PlanetaryPosition {
+        PlanetaryPosition {
+            planet,
+            longitude: 0.0,
+            sign,
+            retrograde: false,
+            moon_phase: if planet == Planet::Moon {
+                Some(MoonPhase::FullMoon)
+            } else {
+                None
+            },
+        }
+    }
+
+    fn full_natal(mars_sign: ZodiacSign) -> Vec<PlanetaryPosition> {
+        vec![
+            make_position(Planet::Sun,     ZodiacSign::Leo),
+            make_position(Planet::Moon,    ZodiacSign::Cancer),
+            make_position(Planet::Mercury, ZodiacSign::Gemini),
+            make_position(Planet::Venus,   ZodiacSign::Taurus),
+            make_position(Planet::Mars,    mars_sign),
+            make_position(Planet::Jupiter, ZodiacSign::Sagittarius),
+            make_position(Planet::Saturn,  ZodiacSign::Capricorn),
+        ]
+    }
+
+    #[test]
+    fn test_registry_creation() {
+        let registry = ProcessRegistry::new(false);
+        assert!(!registry.use_13_signs);
+        assert!(registry.charts.is_empty());
+
+        let registry_13 = ProcessRegistry::new(true);
+        assert!(registry_13.use_13_signs);
+    }
+
+    #[test]
+    fn test_nonexistent_pid() {
+        let result = ProcessBirthChart::from_pid(9_999_999, false);
+        assert!(result.is_none(), "Expected None for non-existent PID");
+    }
+
+    #[test]
+    fn test_compatibility_same_element() {
+        // Mars in Aries (Fire) vs current Mars in Leo (Fire) → same element
+        let chart = ProcessBirthChart {
+            pid: 1,
+            birth_time: Utc::now(),
+            sun_sign: ZodiacSign::Leo,
+            ascendant_element: Element::Fire,
+            natal_moon_phase: MoonPhase::FullMoon,
+            natal_positions: full_natal(ZodiacSign::Aries), // Mars = Fire
+        };
+
+        let current = vec![make_position(Planet::Mars, ZodiacSign::Leo)]; // Fire
+        let m = chart.compatibility_with_current(&current, TaskType::CpuIntensive);
+        assert!(m > 1.0, "Same element should yield > 1.0, got {m}");
+    }
+
+    #[test]
+    fn test_compatibility_opposing_element() {
+        // Mars in Aries (Fire) vs current Mars in Cancer (Water) → opposing
+        let chart = ProcessBirthChart {
+            pid: 2,
+            birth_time: Utc::now(),
+            sun_sign: ZodiacSign::Leo,
+            ascendant_element: Element::Fire,
+            natal_moon_phase: MoonPhase::NewMoon,
+            natal_positions: full_natal(ZodiacSign::Aries), // Mars = Fire
+        };
+
+        let current = vec![make_position(Planet::Mars, ZodiacSign::Cancer)]; // Water opposes Fire
+        let m = chart.compatibility_with_current(&current, TaskType::CpuIntensive);
+        assert!(m < 1.0, "Opposing elements should yield < 1.0, got {m}");
+    }
+}

--- a/src/astrology/mod.rs
+++ b/src/astrology/mod.rs
@@ -1,6 +1,9 @@
 pub mod planets;
 pub mod tasks;
 pub mod scheduler;
+pub mod aspects;
+pub mod birth_chart;
+pub mod predictions;
 
 // Public API re-exports for external use
 #[allow(unused_imports)]
@@ -9,3 +12,11 @@ pub use planets::{Planet, ZodiacSign, Element, PlanetaryPosition, MoonPhase, cal
 pub use tasks::{TaskType, TaskClassifier};
 #[allow(unused_imports)]
 pub use scheduler::{AstrologicalScheduler, SchedulingDecision};
+#[allow(unused_imports)]
+pub use aspects::{AspectType, AspectNature, Aspect, calculate_aspects, aspects_for_planet,
+                  combined_aspect_modifier, describe_aspects};
+#[allow(unused_imports)]
+pub use birth_chart::{ProcessBirthChart, ProcessRegistry};
+#[allow(unused_imports)]
+pub use predictions::{CompletionTimeRange, HoroscopePrediction, get_system_daily_horoscope,
+                      format_duration, confidence_stars};

--- a/src/astrology/predictions.rs
+++ b/src/astrology/predictions.rs
@@ -1,0 +1,935 @@
+use super::planets::{Planet, PlanetaryPosition, Element};
+use super::tasks::TaskType;
+use chrono::{DateTime, Utc, Datelike, Timelike};
+
+/// Estimated time range for task completion, with cosmic justification.
+#[derive(Debug, Clone)]
+pub struct CompletionTimeRange {
+    pub min_seconds: u64,
+    pub max_seconds: u64,
+    /// 0.0 = "I asked a Magic 8-Ball", 1.0 = "Newtonian certainty"
+    pub confidence: f64,
+    pub cosmic_reason: String,
+}
+
+/// A full horoscope prediction for a given task type.
+#[derive(Debug, Clone)]
+pub struct HoroscopePrediction {
+    pub task_type: TaskType,
+    pub ruling_planet: Planet,
+    pub completion_estimate: CompletionTimeRange,
+    pub daily_forecast: String,
+    pub lucky_number: u8,
+    /// 0-23: the best hour of day to run this task type, per planetary wisdom
+    pub power_hour: u8,
+}
+
+fn task_type_ordinal(t: TaskType) -> u64 {
+    match t {
+        TaskType::Network      => 0,
+        TaskType::CpuIntensive => 1,
+        TaskType::Desktop      => 2,
+        TaskType::MemoryHeavy  => 3,
+        TaskType::System       => 4,
+        TaskType::Interactive  => 5,
+        TaskType::Critical     => 6,
+    }
+}
+
+impl HoroscopePrediction {
+    pub fn generate(
+        positions: &[PlanetaryPosition],
+        task_type: TaskType,
+        now: &DateTime<Utc>,
+    ) -> Self {
+        let ruling_planet = task_type.ruling_planet();
+
+        // Find ruling planet's position (fall back to a synthetic one if absent)
+        let ruling_pos = positions
+            .iter()
+            .find(|p| p.planet == ruling_planet)
+            .cloned()
+            .unwrap_or_else(|| PlanetaryPosition {
+                planet: ruling_planet,
+                longitude: 0.0,
+                sign: super::planets::ZodiacSign::Aries,
+                retrograde: false,
+                moon_phase: None,
+            });
+
+        let element = ruling_pos.sign.element();
+        let sign_name = ruling_pos.sign.name();
+        let planet_name = ruling_planet.name();
+
+        // ── Base time ranges (min_s, max_s) per task type ──────────────────
+        let (base_min, base_max): (u64, u64) = match task_type {
+            TaskType::CpuIntensive => (120,  3600),
+            TaskType::Network      => (5,    300),
+            TaskType::MemoryHeavy  => (60,   1800),
+            TaskType::System       => (1,    60),
+            TaskType::Interactive  => (1,    30),
+            TaskType::Desktop      => (1,    10),
+            TaskType::Critical     => (1,    1),
+        };
+
+        // ── Retrograde multiplier ──────────────────────────────────────────
+        let retro_multiplier: f64 = if ruling_pos.retrograde { 3.0 } else { 1.0 };
+
+        // ── Element speed modifier (Fire=fast, Earth=slow, Air/Water=medium) ─
+        let element_multiplier: f64 = match element {
+            Element::Fire  => 0.75,
+            Element::Earth => 1.50,
+            Element::Air   => 1.00,
+            Element::Water => 1.25,
+        };
+
+        let combined = retro_multiplier * element_multiplier;
+        let adj_min = ((base_min as f64) * combined).round() as u64;
+        let adj_max = ((base_max as f64) * combined).round() as u64;
+        // Clamp so min is always at least 1
+        let final_min = adj_min.max(1);
+        let final_max = adj_max.max(final_min);
+
+        // ── Confidence ────────────────────────────────────────────────────
+        // Retrograde tanks confidence; earthy stability helps it.
+        let confidence: f64 = {
+            let base = if ruling_pos.retrograde { 0.45 } else { 0.80 };
+            let element_bonus: f64 = match element {
+                Element::Earth => 0.15,
+                Element::Fire  => 0.05,
+                Element::Air   => 0.00,
+                Element::Water => -0.05,
+            };
+            (base + element_bonus).clamp(0.05, 1.0)
+        };
+
+        // ── Cosmic reason string ──────────────────────────────────────────
+        let motion = if ruling_pos.retrograde { "retrograde" } else { "direct" };
+        let element_quip: &str = match element {
+            Element::Fire  => match task_type {
+                TaskType::CpuIntensive => "CPU burns bright!",
+                TaskType::Network      => "packets ignite like solar flares!",
+                TaskType::Desktop      => "pixels dance with fiery grace!",
+                TaskType::MemoryHeavy  => "RAM blazes with celestial fuel!",
+                TaskType::System       => "kernel ignites with volcanic precision!",
+                TaskType::Interactive  => "your shell crackles with warmth!",
+                TaskType::Critical     => "the cosmos holds its breath!",
+            },
+            Element::Earth => match task_type {
+                TaskType::CpuIntensive => "compilation plods but endures!",
+                TaskType::Network      => "packets travel like tectonic plates!",
+                TaskType::Desktop      => "pixels settle, unmoving as mountains!",
+                TaskType::MemoryHeavy  => "memory grows slow and deep as bedrock!",
+                TaskType::System       => "the kernel stands firm as granite!",
+                TaskType::Interactive  => "your keystrokes echo through stone!",
+                TaskType::Critical     => "the foundation holds all things!",
+            },
+            Element::Air   => match task_type {
+                TaskType::CpuIntensive => "threads drift on cosmic winds!",
+                TaskType::Network      => "packets flow like starlight!",
+                TaskType::Desktop      => "windows flutter like butterfly wings!",
+                TaskType::MemoryHeavy  => "heap allocations float on gentle breeze!",
+                TaskType::System       => "daemons whisper through the ether!",
+                TaskType::Interactive  => "your commands ride the celestial zephyr!",
+                TaskType::Critical     => "the vital spark breathes free!",
+            },
+            Element::Water => match task_type {
+                TaskType::CpuIntensive => "cycles flow like a mountain stream!",
+                TaskType::Network      => "packets ripple through digital tides!",
+                TaskType::Desktop      => "frames cascade like gentle waterfalls!",
+                TaskType::MemoryHeavy  => "data pools in deep lunar lakes!",
+                TaskType::System       => "the kernel ebbs and flows!",
+                TaskType::Interactive  => "your session swirls in the cosmic ocean!",
+                TaskType::Critical     => "the lifeblood of the machine churns!",
+            },
+        };
+
+        let cosmic_reason = format!(
+            "{} {} in {} ({}) — {}",
+            planet_name, motion, sign_name, element.name(), element_quip
+        );
+
+        // ── Daily forecast ────────────────────────────────────────────────
+        let daily_forecast = generate_daily_forecast(
+            ruling_planet,
+            &ruling_pos,
+            task_type,
+            now,
+        );
+
+        // ── Lucky number ──────────────────────────────────────────────────
+        let lucky_number = ((ruling_pos.longitude as u64 + task_type_ordinal(task_type)) % 99 + 1) as u8;
+
+        // ── Power hour ────────────────────────────────────────────────────
+        let power_hour: u8 = match ruling_planet {
+            Planet::Sun     => 12,
+            Planet::Moon    => 0,
+            Planet::Mercury => 9,
+            Planet::Venus   => 18,
+            Planet::Mars    => 6,
+            Planet::Jupiter => 15,
+            Planet::Saturn  => 21,
+        };
+
+        HoroscopePrediction {
+            task_type,
+            ruling_planet,
+            completion_estimate: CompletionTimeRange {
+                min_seconds: final_min,
+                max_seconds: final_max,
+                confidence,
+                cosmic_reason,
+            },
+            daily_forecast,
+            lucky_number,
+            power_hour,
+        }
+    }
+
+}
+
+fn generate_daily_forecast(
+    planet: Planet,
+    pos: &PlanetaryPosition,
+    _task_type: TaskType,
+    now: &DateTime<Utc>,
+) -> String {
+    let sign = pos.sign.name();
+    let element = pos.sign.element();
+    let retro = pos.retrograde;
+    // Use hour to add slight time-of-day flavor
+    let hour = now.hour();
+
+    // Moon phase flavoring for Moon-ruled tasks
+    let moon_phase_note = if planet == Planet::Moon {
+        if let Some(phase) = pos.moon_phase {
+            format!(" The {} Moon amplifies your intentions.", phase.name())
+        } else {
+            String::new()
+        }
+    } else {
+        String::new()
+    };
+
+    // 6+ variations per planet based on sign element + retrograde
+    let base_forecast = match planet {
+        Planet::Mars => {
+            if retro {
+                match element {
+                    Element::Fire => format!(
+                        "Mars retreats through {}, its war-drums muffled by cosmic static. \
+                         Your CPU cores are present, but emotionally unavailable. \
+                         Recompile with lower expectations — and maybe a snack.",
+                        sign
+                    ),
+                    Element::Earth => format!(
+                        "Mars trudges backward through {}, dragging its compile flags through \
+                         the mud. Progress is measured in geological epochs. \
+                         Consider a nap. Or three.",
+                        sign
+                    ),
+                    Element::Air => format!(
+                        "Mars spirals retrograde through airy {}, scattering your \
+                         build artifacts like autumn leaves. The linker weeps. \
+                         Your patience will be tested by the cosmos and the cache.",
+                        sign
+                    ),
+                    Element::Water => format!(
+                        "Mars drifts backward through watery {}, your compilation \
+                         submerged in cosmic molasses. Threads stall. Cores dream. \
+                         Breathe deep — even Olympus had compile errors.",
+                        sign
+                    ),
+                }
+            } else {
+                match element {
+                    Element::Fire => format!(
+                        "Mars blazes through {} with reckless abandon! Your compilation \
+                         burns with cosmic fire. Expect the unexpected — the stars promise \
+                         chaos, but glorious chaos!",
+                        sign
+                    ),
+                    Element::Earth => format!(
+                        "Mars marches steadily through {}, your CPU cores disciplined \
+                         as Roman legions. Compilation proceeds with earthy determination. \
+                         Slow? Yes. But it will finish. Eventually.",
+                        sign
+                    ),
+                    Element::Air => format!(
+                        "Mars dances through {}, threads pirouetting on celestial breezes. \
+                         Your code compiles swiftly, borne aloft by cosmic tailwinds. \
+                         May your linker be ever in your favor.",
+                        sign
+                    ),
+                    Element::Water => format!(
+                        "Mars flows through {}, your build process surging like a river \
+                         in flood. Powerful, fluid, slightly unpredictable. \
+                         Keep your Makefile dry.",
+                        sign
+                    ),
+                }
+            }
+        }
+
+        Planet::Mercury => {
+            if retro {
+                match element {
+                    Element::Fire => format!(
+                        "Mercury retrograde scorches through {}! Packets combust spontaneously. \
+                         Your SSH sessions drop not from server error, but from cosmic disapproval. \
+                         Back up your configs. The stars recommend it urgently.",
+                        sign
+                    ),
+                    Element::Earth => format!(
+                        "Mercury crawls backward through {}, dragging your TCP handshakes \
+                         through sedimentary time. Every ping a geological event. \
+                         Consider carrier pigeons as a fallback protocol.",
+                        sign
+                    ),
+                    Element::Air => format!(
+                        "Mercury double-backs through {}, scattering packets to the four winds. \
+                         DNS resolves to yesterday. TLS certificates have opinions. \
+                         The universe apologizes for the inconvenience.",
+                        sign
+                    ),
+                    Element::Water => format!(
+                        "Mercury swims upstream through {}, your network traffic eddying \
+                         in cosmic backwash. Latency spikes. Connections time out philosophically. \
+                         This too shall pass — but slowly.",
+                        sign
+                    ),
+                }
+            } else {
+                match element {
+                    Element::Fire => format!(
+                        "Mercury races through fiery {}! Packets ignite with purpose, \
+                         your network blazing trails through the ether. \
+                         Download speeds ascend. The gods of bandwidth smile.",
+                        sign
+                    ),
+                    Element::Earth => format!(
+                        "Mercury grounds itself in {}, your network traffic steady and reliable \
+                         as tectonic plates — if slightly slower. \
+                         Reliable. Predictable. Boringly excellent.",
+                        sign
+                    ),
+                    Element::Air => format!(
+                        "Mercury soars through {}, packets flowing like starlight through the void! \
+                         Your connections snap into place with divine efficiency. \
+                         The cosmic routers are on your side today.",
+                        sign
+                    ),
+                    Element::Water => format!(
+                        "Mercury drifts through {}, your data streams rippling with gentle purpose. \
+                         Network traffic flows in tranquil currents. \
+                         Latency is low. The ocean of bits is calm.",
+                        sign
+                    ),
+                }
+            }
+        }
+
+        Planet::Venus => {
+            if retro {
+                match element {
+                    Element::Fire => format!(
+                        "Venus retreats through fiery {}! Your desktop flickers with \
+                         unrequited rendering. Windows refuse to redraw. Icons sulk. \
+                         Your compositor needs a hug it won't receive.",
+                        sign
+                    ),
+                    Element::Earth => format!(
+                        "Venus trudges backward through {}, your UI elements stubbornly \
+                         refusing to refresh. Pixel art from a bygone era haunts your screen. \
+                         Embrace the aesthetic. It is the aesthetic now.",
+                        sign
+                    ),
+                    Element::Air => format!(
+                        "Venus floats backward through {}, scattering your window layouts \
+                         to the cosmic breeze. Tiling managers weep. Floating windows \
+                         float where they will. Resistance is futile and also not calming.",
+                        sign
+                    ),
+                    Element::Water => format!(
+                        "Venus dissolves backward through {}, your screen smearing \
+                         like watercolors in rain. Frame rate dips. Vsync becomes \
+                         an aspiration rather than a guarantee.",
+                        sign
+                    ),
+                }
+            } else {
+                match element {
+                    Element::Fire => format!(
+                        "Venus dances through {}, your desktop ablaze with gorgeous frames! \
+                         Animations are buttery. Icons glow with inner radiance. \
+                         Your compositor is having the best day of its life.",
+                        sign
+                    ),
+                    Element::Earth => format!(
+                        "Venus settles into {}, your UI solid and dependable as good furniture. \
+                         No flashy transitions — just honest pixels, rendered with dignity. \
+                         Sturdy. Reliable. Beautifully understated.",
+                        sign
+                    ),
+                    Element::Air => format!(
+                        "Venus glides through {}, your desktop elegant as a Viennese waltz. \
+                         Transitions flow. Fonts kern perfectly. \
+                         Even your terminal emulator looks a little glamorous today.",
+                        sign
+                    ),
+                    Element::Water => format!(
+                        "Venus flows through {}, your interface rippling with liquid grace. \
+                         Smooth gradients. Silky scrolling. \
+                         Your GTK theme has never looked so spiritually nourishing.",
+                        sign
+                    ),
+                }
+            }
+        }
+
+        Planet::Jupiter => {
+            if retro {
+                match element {
+                    Element::Fire => format!(
+                        "Jupiter retreats through {}, your heap contracting with retrograde \
+                         indignation. malloc returns NULL as a lifestyle choice. \
+                         The JVM considers early retirement. Swap space expands to fill the void.",
+                        sign
+                    ),
+                    Element::Earth => format!(
+                        "Jupiter lumbers backward through {}, memory allocations grinding \
+                         to a geological pace. Your database ponders each query with \
+                         the philosophical weight of ages. Patience is a virtue; RAM is a commodity.",
+                        sign
+                    ),
+                    Element::Air => format!(
+                        "Jupiter spirals backward through {}, heap objects drifting loose \
+                         from their pointers. Memory leaks with cosmic abandon. \
+                         The garbage collector runs, but it too is retrograde.",
+                        sign
+                    ),
+                    Element::Water => format!(
+                        "Jupiter drifts backward through {}, your memory pool swirling \
+                         in retrograde eddies. Cache evictions are frequent and sorrowful. \
+                         Even Redis is having feelings about it.",
+                        sign
+                    ),
+                }
+            } else {
+                match element {
+                    Element::Fire => format!(
+                        "Jupiter expands through {}, your memory abundant as cosmic fire! \
+                         The JVM allocates with divine extravagance. \
+                         Heap size is merely a suggestion. The stars say: request more RAM.",
+                        sign
+                    ),
+                    Element::Earth => format!(
+                        "Jupiter grounds through {}, your memory management solid and \
+                         methodical. Pages are allocated with deliberate care. \
+                         Your database grows slowly, like an oak — but magnificent.",
+                        sign
+                    ),
+                    Element::Air => format!(
+                        "Jupiter soars through {}, your application breathing freely in \
+                         vast memory expanses! Objects instantiate with joyful abandon. \
+                         The heap is open sky. Fly, little processes, fly.",
+                        sign
+                    ),
+                    Element::Water => format!(
+                        "Jupiter flows through {}, your memory pools deep and full. \
+                         Allocations swim gracefully. The buffer blooms with plenty. \
+                         Even valgrind is impressed, and valgrind is never impressed.",
+                        sign
+                    ),
+                }
+            }
+        }
+
+        Planet::Saturn => {
+            if retro {
+                match element {
+                    Element::Fire => format!(
+                        "Saturn retreats through {}, system daemons questioning their purpose. \
+                         Cron jobs run when the mood strikes. systemd unit files develop \
+                         strong opinions about dependency order. Structure unravels, cosmically.",
+                        sign
+                    ),
+                    Element::Earth => format!(
+                        "Saturn grinds backward through {}, your system calls taking the \
+                         scenic route through kernel space. Everything works. \
+                         Just... not enthusiastically. The system endures.",
+                        sign
+                    ),
+                    Element::Air => format!(
+                        "Saturn drifts backward through {}, daemons whispering conflicting \
+                         instructions to the scheduler. IRQ storms gather on the horizon. \
+                         Consider rebooting. The stars would understand.",
+                        sign
+                    ),
+                    Element::Water => format!(
+                        "Saturn ebbs backward through {}, kernel threads pooling in \
+                        existential eddies. The init system has doubts. \
+                         journald logs feelings instead of events.",
+                        sign
+                    ),
+                }
+            } else {
+                match element {
+                    Element::Fire => format!(
+                        "Saturn marches through {}, system services snapping to attention! \
+                         Daemons start promptly. Cron jobs execute with military precision. \
+                         The kernel is on time, on task, and mildly intimidating.",
+                        sign
+                    ),
+                    Element::Earth => format!(
+                        "Saturn settles through {}, your system stable as continental bedrock. \
+                         Every syscall lands cleanly. Every daemon persists reliably. \
+                         This is what peak kernel performance looks like.",
+                        sign
+                    ),
+                    Element::Air => format!(
+                        "Saturn glides through {}, system processes light and efficient. \
+                         Interrupt latency is a pleasant fiction. \
+                         The scheduler hums in tune with the celestial spheres.",
+                        sign
+                    ),
+                    Element::Water => format!(
+                        "Saturn flows through {}, kernel threads streaming in orderly \
+                         procession. System calls return swiftly and without drama. \
+                         The OS is in flow state. Appreciate it while it lasts.",
+                        sign
+                    ),
+                }
+            }
+        }
+
+        Planet::Moon => {
+            let phase_str = pos.moon_phase.map(|p| p.name()).unwrap_or("present");
+            if retro {
+                // Moon doesn't retrograde, but handle gracefully
+                format!(
+                    "The {} Moon lingers in {}, your shell sessions contemplative and slow. \
+                     Tab completion pauses to reflect on the nature of file paths. \
+                     Terminal emulators emit soft sighs.{}",
+                    phase_str, sign, moon_phase_note
+                )
+            } else {
+                match element {
+                    Element::Fire => format!(
+                        "The {} Moon blazes through {}, your terminal crackles with \
+                         interactive energy! Commands execute with passion. \
+                         Even `ls` feels thrilling.{}",
+                        phase_str, sign, moon_phase_note
+                    ),
+                    Element::Earth => format!(
+                        "The {} Moon grounds through {}, your interactive sessions \
+                         steady and methodical. Bash history is consulted wisely. \
+                         Typos are minimal. The cosmos rewards deliberate typing.{}",
+                        phase_str, sign, moon_phase_note
+                    ),
+                    Element::Air => format!(
+                        "The {} Moon drifts through {}, your shell sessions light and \
+                         responsive as a feather! Autocomplete flows like poetry. \
+                         The terminal is your oyster.{}",
+                        phase_str, sign, moon_phase_note
+                    ),
+                    Element::Water => format!(
+                        "The {} Moon glimmers through {}, your interactive tasks \
+                         flowing in gentle rhythms. Pipe chains cascade like waterfalls. \
+                         Your awk one-liners are briefly beautiful.{}",
+                        phase_str, sign, moon_phase_note
+                    ),
+                }
+            }
+        }
+
+        Planet::Sun => {
+            // Critical tasks ruled by the Sun
+            let time_blessing = if hour >= 10 && hour <= 14 {
+                "The Sun is near its zenith — critical processes bask in full solar power."
+            } else if hour < 6 || hour >= 20 {
+                "The Sun slumbers below the horizon, yet critical processes never sleep."
+            } else {
+                "The Sun blesses this hour with steady, life-giving radiance."
+            };
+            format!(
+                "The Sun holds court in {}, and your most critical processes are \
+                 under direct divine patronage. PID 1 does not negotiate with retrograde. \
+                 {} All hail the init system.",
+                sign, time_blessing
+            )
+        }
+    };
+
+    base_forecast
+}
+
+pub fn format_duration(min_s: u64, max_s: u64) -> String {
+    // Choose unit based on the larger end of the range
+    if max_s < 120 {
+        // Show in seconds
+        if min_s == max_s {
+            format!("{} second{}", min_s, if min_s == 1 { "" } else { "s" })
+        } else {
+            format!("{}-{} seconds", min_s, max_s)
+        }
+    } else if max_s < 3600 {
+        // Show in minutes
+        let min_m = (min_s + 59) / 60; // ceil
+        let max_m = max_s / 60;        // floor
+        let min_m = min_m.max(1);
+        let max_m = max_m.max(min_m);
+        if min_m == max_m {
+            format!("{} minute{}", min_m, if min_m == 1 { "" } else { "s" })
+        } else {
+            format!("{}-{} minutes", min_m, max_m)
+        }
+    } else {
+        // Show in hours
+        let min_h = (min_s + 3599) / 3600; // ceil
+        let max_h = max_s / 3600;           // floor
+        let min_h = min_h.max(1);
+        let max_h = max_h.max(min_h);
+        if min_h == max_h {
+            format!("{} hour{}", min_h, if min_h == 1 { "" } else { "s" })
+        } else {
+            format!("{}-{} hours", min_h, max_h)
+        }
+    }
+}
+
+pub fn confidence_stars(confidence: f64) -> String {
+    let filled = (confidence * 5.0).round() as usize;
+    let filled = filled.min(5);
+    let empty = 5 - filled;
+    format!("{}{}", "★".repeat(filled), "☆".repeat(empty))
+}
+
+fn word_wrap(text: &str, width: usize, indent: &str) -> String {
+    let mut lines = Vec::new();
+    let mut current_line = String::new();
+
+    for word in text.split_whitespace() {
+        if current_line.is_empty() {
+            current_line.push_str(word);
+        } else if current_line.len() + 1 + word.len() <= width {
+            current_line.push(' ');
+            current_line.push_str(word);
+        } else {
+            lines.push(format!("{}{}", indent, current_line));
+            current_line = word.to_string();
+        }
+    }
+    if !current_line.is_empty() {
+        lines.push(format!("{}{}", indent, current_line));
+    }
+    lines.join("\n")
+}
+
+// Cosmic wisdom quotes, rotated by day of month
+const COSMIC_WISDOM: &[&str] = &[
+    "\"The CPU is the mind, RAM the imagination, and disk the long memory of the machine. \
+     Tend them as you would tend your soul.\"",
+    "\"Mercury retrograde is not an excuse — it is an explanation. There is a difference, \
+     and your coworkers will not appreciate the distinction.\"",
+    "\"A process that completes under Mars is forged in fire. \
+     A process that completes under Saturn merely completes. Both are worthy.\"",
+    "\"The scheduler does not play favorites. The planets, however, absolutely do.\"",
+    "\"Even the mightiest kernel panic is written in the stars. \
+     This does not make it less catastrophic.\"",
+    "\"Jupiter in retrograde is why your Electron app uses 8 GB of RAM. \
+     Jupiter direct is why it only uses 6 GB. Plan accordingly.\"",
+    "\"The Full Moon brings peak interactivity and also, inexplicably, \
+     more Slack notifications. This is not a coincidence.\"",
+    "\"Saturn rules structure, discipline, and the /etc directory. \
+     Do not modify /etc during a Saturn retrograde. You have been warned.\"",
+];
+
+pub fn get_system_daily_horoscope(
+    positions: &[PlanetaryPosition],
+    now: &DateTime<Utc>,
+) -> String {
+    let mut out = String::new();
+
+    // ── Date header ──────────────────────────────────────────────────────────
+    out.push_str(&format!(
+        "\
+╔══════════════════════════════════════════════════════════════╗
+║         \u{2728} SYSTEM DAILY HOROSCOPE — {} ✨         ║
+╚══════════════════════════════════════════════════════════════╝
+
+",
+        now.format("%Y-%m-%d %H:%M UTC")
+    ));
+
+    // ── Planets of the day ───────────────────────────────────────────────────
+    out.push_str("\u{1F315} PLANETS OF THE DAY\n");
+    out.push_str("──────────────────────────────────────────────────────────────\n");
+
+    // Find the most "influential" planets: prefer direct planets, then retrograde
+    let mut planet_lines: Vec<String> = Vec::new();
+    for pos in positions {
+        let retro_tag = if pos.retrograde { " ℞ RETROGRADE" } else { "" };
+        let moon_tag = if let Some(phase) = pos.moon_phase {
+            format!(" [{}]", phase.name())
+        } else {
+            String::new()
+        };
+        planet_lines.push(format!(
+            "  {:8} in {:12} ({:5}){}{} — {}",
+            pos.planet.name(),
+            pos.sign.name(),
+            pos.sign.element().name(),
+            retro_tag,
+            moon_tag,
+            pos.planet.domain(),
+        ));
+    }
+    // Show direct planets first, then retrograde
+    planet_lines.sort_by_key(|l| if l.contains("RETROGRADE") { 1u8 } else { 0u8 });
+    for line in &planet_lines {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push('\n');
+
+    // ── Per-task-type guidance ───────────────────────────────────────────────
+    out.push_str("\u{1F4CB} TASK TYPE GUIDANCE\n");
+    out.push_str("──────────────────────────────────────────────────────────────\n\n");
+
+    let all_tasks = [
+        TaskType::Critical,
+        TaskType::CpuIntensive,
+        TaskType::Network,
+        TaskType::MemoryHeavy,
+        TaskType::System,
+        TaskType::Desktop,
+        TaskType::Interactive,
+    ];
+
+    for &task in &all_tasks {
+        let prediction = HoroscopePrediction::generate(positions, task, now);
+        let est = &prediction.completion_estimate;
+        let duration = format_duration(est.min_seconds, est.max_seconds);
+        let stars = confidence_stars(est.confidence);
+
+        out.push_str(&format!(
+            "\u{1F538} {} (ruled by {})\n",
+            task.name(),
+            prediction.ruling_planet.name()
+        ));
+        out.push_str(&format!(
+            "   Estimated: {}  |  Confidence: {}  |  Power hour: {:02}:00  |  Lucky #: {}\n",
+            duration,
+            stars,
+            prediction.power_hour,
+            prediction.lucky_number,
+        ));
+        // Wrap the forecast at 60 chars
+        out.push_str(&word_wrap(&prediction.daily_forecast, 60, "   "));
+        out.push('\n');
+        out.push_str(&format!("   \u{1F30C} {}\n", est.cosmic_reason));
+        out.push('\n');
+    }
+
+    // ── Cosmic wisdom quote (rotate by day of month) ─────────────────────────
+    let day_idx = (now.day0() as usize) % COSMIC_WISDOM.len();
+    out.push_str("──────────────────────────────────────────────────────────────\n");
+    out.push_str("\u{1F4AB} COSMIC WISDOM OF THE DAY:\n\n   ");
+    out.push_str(COSMIC_WISDOM[day_idx]);
+    out.push_str("\n\n");
+    out.push_str("══════════════════════════════════════════════════════════════\n");
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::planets::{ZodiacSign, MoonPhase, calculate_planetary_positions};
+    use chrono::TimeZone;
+
+    /// Build a minimal set of positions without calling the real astro crate.
+    fn mock_positions() -> Vec<PlanetaryPosition> {
+        vec![
+            PlanetaryPosition {
+                planet: Planet::Sun,
+                longitude: 45.0,
+                sign: ZodiacSign::Taurus,
+                retrograde: false,
+                moon_phase: None,
+            },
+            PlanetaryPosition {
+                planet: Planet::Moon,
+                longitude: 120.0,
+                sign: ZodiacSign::Leo,
+                retrograde: false,
+                moon_phase: Some(MoonPhase::FirstQuarter),
+            },
+            PlanetaryPosition {
+                planet: Planet::Mercury,
+                longitude: 200.0,
+                sign: ZodiacSign::Libra,
+                retrograde: false,
+                moon_phase: None,
+            },
+            PlanetaryPosition {
+                planet: Planet::Venus,
+                longitude: 300.0,
+                sign: ZodiacSign::Aquarius,
+                retrograde: false,
+                moon_phase: None,
+            },
+            PlanetaryPosition {
+                planet: Planet::Mars,
+                longitude: 15.0,
+                sign: ZodiacSign::Aries,
+                retrograde: false,
+                moon_phase: None,
+            },
+            PlanetaryPosition {
+                planet: Planet::Jupiter,
+                longitude: 90.0,
+                sign: ZodiacSign::Cancer,
+                retrograde: true,
+                moon_phase: None,
+            },
+            PlanetaryPosition {
+                planet: Planet::Saturn,
+                longitude: 330.0,
+                sign: ZodiacSign::Pisces,
+                retrograde: false,
+                moon_phase: None,
+            },
+        ]
+    }
+
+    fn test_now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 2, 27, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn test_prediction_generation() {
+        let positions = mock_positions();
+        let now = test_now();
+
+        let task_types = [
+            TaskType::Network,
+            TaskType::CpuIntensive,
+            TaskType::Desktop,
+            TaskType::MemoryHeavy,
+            TaskType::System,
+            TaskType::Interactive,
+            TaskType::Critical,
+        ];
+
+        for &task in &task_types {
+            let pred = HoroscopePrediction::generate(&positions, task, &now);
+
+            // Basic sanity checks
+            assert!(!pred.daily_forecast.is_empty(),
+                "daily_forecast should not be empty for {:?}", task);
+            assert!(!pred.completion_estimate.cosmic_reason.is_empty(),
+                "cosmic_reason should not be empty for {:?}", task);
+            assert!(pred.lucky_number >= 1 && pred.lucky_number <= 99,
+                "lucky_number out of range for {:?}: {}", task, pred.lucky_number);
+            assert!(pred.power_hour <= 23,
+                "power_hour out of range for {:?}: {}", task, pred.power_hour);
+            assert!(pred.completion_estimate.confidence >= 0.0
+                && pred.completion_estimate.confidence <= 1.0,
+                "confidence out of range for {:?}: {}", task, pred.completion_estimate.confidence);
+            assert!(pred.completion_estimate.min_seconds >= 1,
+                "min_seconds should be at least 1 for {:?}", task);
+            assert!(pred.completion_estimate.max_seconds >= pred.completion_estimate.min_seconds,
+                "max_seconds should be >= min_seconds for {:?}", task);
+        }
+    }
+
+    #[test]
+    fn test_format_duration() {
+        // Small ranges → seconds
+        assert_eq!(format_duration(1, 1), "1 second");
+        assert_eq!(format_duration(5, 60), "5-60 seconds");
+        assert_eq!(format_duration(30, 90), "30-90 seconds");
+        assert!(format_duration(5, 60).contains("seconds"));
+
+        // Medium ranges → minutes
+        assert!(format_duration(60, 600).contains("minutes"));
+        assert!(format_duration(120, 1800).contains("minutes"));
+        let min_str = format_duration(120, 1800);
+        assert!(min_str.contains("minute"), "Expected 'minute' in '{}'", min_str);
+
+        // Large ranges → hours
+        let hour_str = format_duration(3600, 14400);
+        assert!(hour_str.contains("hour"), "Expected 'hour' in '{}'", hour_str);
+        assert_eq!(format_duration(3600, 3600), "1 hour");
+    }
+
+    #[test]
+    fn test_confidence_stars() {
+        assert_eq!(confidence_stars(1.0), "★★★★★");
+        assert_eq!(confidence_stars(0.0), "☆☆☆☆☆");
+
+        // 0.8 → rounds to 4 filled
+        let stars_80 = confidence_stars(0.8);
+        assert_eq!(stars_80, "★★★★☆",
+            "0.8 confidence should be 4 stars, got '{}'", stars_80);
+
+        // 0.6 → rounds to 3 filled
+        let stars_60 = confidence_stars(0.6);
+        assert_eq!(stars_60, "★★★☆☆",
+            "0.6 confidence should be 3 stars, got '{}'", stars_60);
+
+        // Always 5 total characters
+        for &c in &[0.0, 0.2, 0.4, 0.6, 0.8, 1.0] {
+            let s = confidence_stars(c);
+            let count: usize = s.chars().count();
+            assert_eq!(count, 5, "confidence_stars({}) should have 5 chars, got {}", c, count);
+        }
+    }
+
+    #[test]
+    fn test_system_horoscope() {
+        let positions = mock_positions();
+        let now = test_now();
+
+        let horoscope = get_system_daily_horoscope(&positions, &now);
+
+        assert!(!horoscope.is_empty(), "System horoscope should not be empty");
+        assert!(horoscope.contains("HOROSCOPE"),
+            "System horoscope should contain 'HOROSCOPE'");
+        assert!(horoscope.contains("PLANETS OF THE DAY"),
+            "System horoscope should contain planets section");
+        assert!(horoscope.contains("TASK TYPE GUIDANCE"),
+            "System horoscope should contain task guidance section");
+        assert!(horoscope.contains("COSMIC WISDOM"),
+            "System horoscope should contain wisdom section");
+
+        // Should mention all task type names
+        for name in &["CPU-Intensive", "Network", "Memory-Heavy", "System",
+                      "Desktop/UI", "Interactive", "Critical"] {
+            assert!(horoscope.contains(name),
+                "System horoscope should mention task type '{}'", name);
+        }
+    }
+
+    /// Integration test: use real planetary positions from the astro crate
+    /// (same date as existing planets.rs tests).
+    #[test]
+    fn test_real_positions_prediction() {
+        let test_time = Utc.with_ymd_and_hms(2025, 11, 19, 22, 7, 46).unwrap();
+        let positions = calculate_planetary_positions(test_time);
+
+        let pred = HoroscopePrediction::generate(
+            &positions,
+            TaskType::CpuIntensive,
+            &test_time,
+        );
+
+        // Mars should be the ruling planet for CpuIntensive
+        assert_eq!(pred.ruling_planet, Planet::Mars);
+        assert_eq!(pred.power_hour, 6);
+        assert!(!pred.daily_forecast.is_empty());
+        assert!(pred.daily_forecast.contains("Mars") || pred.completion_estimate.cosmic_reason.contains("Mars"));
+    }
+}

--- a/src/astrology/scheduler.rs
+++ b/src/astrology/scheduler.rs
@@ -1,7 +1,11 @@
-use super::planets::{Planet, Element, PlanetaryPosition, MoonPhase, calculate_planetary_positions_with_zodiac};
+use super::planets::{Planet, Element, PlanetaryPosition, MoonPhase,
+                     calculate_planetary_positions_with_zodiac};
 #[cfg(test)]
 use super::planets::calculate_planetary_positions;
 use super::tasks::{TaskType, TaskClassifier};
+use super::aspects::{calculate_aspects, combined_aspect_modifier, describe_aspects};
+use super::birth_chart::ProcessRegistry;
+use super::predictions::{HoroscopePrediction, get_system_daily_horoscope};
 use chrono::{DateTime, Utc};
 
 /// Scheduling decision with astrological reasoning
@@ -19,7 +23,50 @@ pub struct AstrologicalScheduler {
     classifier: TaskClassifier,
     planetary_cache: Option<(DateTime<Utc>, Vec<PlanetaryPosition>)>,
     cache_duration_secs: i64,
-    use_13_signs: bool,  // Use 13-sign zodiac with Ophiuchus (IAU boundaries)
+    use_13_signs: bool,       // Use 13-sign zodiac with Ophiuchus (IAU boundaries)
+    birth_registry: ProcessRegistry,  // Natal charts for running processes
+    enable_birth_charts: bool,
+    enable_aspects: bool,
+    enable_predictions: bool,
+    enable_cpu_affinity: bool,
+}
+
+/// Which CPU element is "attuned" to a given CPU index (0-based)
+/// Cycle: Fire, Earth, Air, Water — groups of 3 CPUs each
+fn cpu_element(cpu_index: i32) -> Element {
+    match cpu_index.rem_euclid(4) {
+        0 => Element::Fire,
+        1 => Element::Earth,
+        2 => Element::Air,
+        _ => Element::Water,
+    }
+}
+
+/// Astrological compatibility between a task's element and a CPU's element.
+/// Returns a modifier to apply when computing CPU affinity preference.
+fn cpu_task_affinity(cpu_element: Element, task_element: Element) -> f64 {
+    if cpu_element == task_element {
+        return 1.5; // Perfect match — this CPU was born for this task
+    }
+    match (cpu_element, task_element) {
+        // Compatible pairs
+        (Element::Fire, Element::Air)   | (Element::Air, Element::Fire)   => 1.2,
+        (Element::Earth, Element::Water)| (Element::Water, Element::Earth) => 1.2,
+        // Opposing pairs
+        (Element::Fire, Element::Water) | (Element::Water, Element::Fire)  => 0.6,
+        (Element::Earth, Element::Air)  | (Element::Air, Element::Earth)   => 0.6,
+        _ => 1.0,
+    }
+}
+
+/// Map element to a simple zodiac sign for display in cosmic weather
+fn element_sign(element: Element) -> &'static str {
+    match element {
+        Element::Fire  => "Aries ♈",
+        Element::Earth => "Taurus ♉",
+        Element::Air   => "Gemini ♊",
+        Element::Water => "Cancer ♋",
+    }
 }
 
 impl AstrologicalScheduler {
@@ -28,11 +75,28 @@ impl AstrologicalScheduler {
     }
 
     pub fn with_options(cache_duration_secs: i64, use_13_signs: bool) -> Self {
+        Self::with_full_options(cache_duration_secs, use_13_signs, false, false, false, false)
+    }
+
+    /// Create scheduler with all feature flags
+    pub fn with_full_options(
+        cache_duration_secs: i64,
+        use_13_signs: bool,
+        enable_birth_charts: bool,
+        enable_aspects: bool,
+        enable_predictions: bool,
+        enable_cpu_affinity: bool,
+    ) -> Self {
         Self {
             classifier: TaskClassifier::new(),
             planetary_cache: None,
             cache_duration_secs,
             use_13_signs,
+            birth_registry: ProcessRegistry::new(use_13_signs),
+            enable_birth_charts,
+            enable_aspects,
+            enable_predictions,
+            enable_cpu_affinity,
         }
     }
 
@@ -40,6 +104,62 @@ impl AstrologicalScheduler {
     #[allow(dead_code)]  // Public API
     pub fn uses_13_signs(&self) -> bool {
         self.use_13_signs
+    }
+
+    /// Get a birth-chart compatibility modifier for a process
+    pub fn birth_chart_modifier(&mut self, pid: i32, current_positions: &[PlanetaryPosition], task_type: TaskType) -> f64 {
+        if !self.enable_birth_charts {
+            return 1.0;
+        }
+        self.birth_registry
+            .get_or_create(pid)
+            .map(|chart| chart.compatibility_with_current(current_positions, task_type))
+            .unwrap_or(1.0)
+    }
+
+    /// Pick the most astrologically compatible CPU for a task
+    /// Returns an optional CPU preference score (higher = better match)
+    pub fn cpu_affinity_score(&self, cpu_index: i32, task_type: TaskType, positions: &[PlanetaryPosition]) -> f64 {
+        if !self.enable_cpu_affinity {
+            return 1.0;
+        }
+
+        let cpu_elem = cpu_element(cpu_index);
+
+        // Task element from ruling planet's current sign
+        let ruling = task_type.ruling_planet();
+        let task_elem = positions.iter()
+            .find(|p| p.planet == ruling)
+            .map(|p| p.sign.element())
+            .unwrap_or(Element::Air);
+
+        cpu_task_affinity(cpu_elem, task_elem)
+    }
+
+    /// Generate a horoscope prediction for a task (for debug logging)
+    pub fn horoscope_prediction(&self, positions: &[PlanetaryPosition], task_type: TaskType, now: DateTime<Utc>) -> Option<HoroscopePrediction> {
+        if self.enable_predictions {
+            Some(HoroscopePrediction::generate(positions, task_type, &now))
+        } else {
+            None
+        }
+    }
+
+    /// Periodically evict dead processes from the birth chart registry
+    pub fn evict_dead_processes(&mut self) {
+        if self.enable_birth_charts {
+            self.birth_registry.evict_dead_processes();
+        }
+    }
+
+    /// Classify a task by command name (public wrapper for main.rs use)
+    pub fn classify_for_affinity(&self, comm: &str) -> TaskType {
+        self.classifier.classify(comm)
+    }
+
+    /// Return a snapshot of the current cached planetary positions
+    pub fn current_positions(&mut self, now: DateTime<Utc>) -> Vec<PlanetaryPosition> {
+        self.get_planetary_positions(now).clone()
     }
 
     fn get_planetary_positions(&mut self, now: DateTime<Utc>) -> &Vec<PlanetaryPosition> {
@@ -90,6 +210,34 @@ impl AstrologicalScheduler {
         }
     }
 
+    /// Moon phase modifier scaled for memory/I-O tasks (subtler tidal effect than Interactive)
+    fn moon_phase_tidal_modifier(phase: MoonPhase) -> f64 {
+        match phase {
+            MoonPhase::FullMoon => 1.2,         // High tide: memory pools swell
+            MoonPhase::WaxingGibbous => 1.1,
+            MoonPhase::FirstQuarter => 1.05,
+            MoonPhase::WaxingCrescent => 1.02,
+            MoonPhase::NewMoon => 0.9,          // Low tide: memory ebbs
+            MoonPhase::WaningGibbous => 0.97,
+            MoonPhase::LastQuarter => 0.95,
+            MoonPhase::WaningCrescent => 0.92,
+        }
+    }
+
+    /// Moon phase modifier for network tasks (Mercury-ruled but flows like tides)
+    fn moon_phase_flow_modifier(phase: MoonPhase) -> f64 {
+        match phase {
+            MoonPhase::FullMoon => 1.15,        // Maximum cosmic bandwidth
+            MoonPhase::WaxingGibbous => 1.08,
+            MoonPhase::FirstQuarter => 1.04,
+            MoonPhase::WaxingCrescent => 1.01,
+            MoonPhase::NewMoon => 0.93,         // Dark moon = dark packets
+            MoonPhase::WaningGibbous => 0.98,
+            MoonPhase::LastQuarter => 0.96,
+            MoonPhase::WaningCrescent => 0.94,
+        }
+    }
+
     fn calculate_element_boost(positions: &[PlanetaryPosition], task_type: TaskType) -> f64 {
         let ruling_planet = task_type.ruling_planet();
 
@@ -133,23 +281,51 @@ impl AstrologicalScheduler {
         let task_type = self.classifier.classify(comm);
         let ruling_planet = task_type.ruling_planet();
 
-        let positions = self.get_planetary_positions(now);
+        // Clone positions immediately so we own the data — this avoids borrow
+        // conflicts when later calling &mut self methods (birth_chart_modifier).
+        let positions: Vec<PlanetaryPosition> = self.get_planetary_positions(now).clone();
 
         let planet_pos = positions.iter()
             .find(|p| p.planet == ruling_planet)
             .expect("Ruling planet should always be present");
 
         let planetary_influence = Self::calculate_planetary_influence(planet_pos);
-        let mut element_boost = Self::calculate_element_boost(positions, task_type);
+        let mut element_boost = Self::calculate_element_boost(&positions, task_type);
 
-        // Apply moon phase boost for Interactive tasks (Moon's domain)
-        if task_type == TaskType::Interactive {
-            if let Some(moon_pos) = positions.iter().find(|p| p.planet == Planet::Moon) {
-                if let Some(phase) = moon_pos.moon_phase {
-                    element_boost *= Self::moon_phase_modifier(phase);
+        // ── Moon phase effects (extended to Memory and Network tasks) ──────────
+        if let Some(moon_pos) = positions.iter().find(|p| p.planet == Planet::Moon) {
+            if let Some(phase) = moon_pos.moon_phase {
+                match task_type {
+                    // Interactive tasks: full moon phase modifier (original)
+                    TaskType::Interactive => {
+                        element_boost *= Self::moon_phase_modifier(phase);
+                    }
+                    // Memory tasks: tidal moon effect on memory pools
+                    TaskType::MemoryHeavy => {
+                        element_boost *= Self::moon_phase_tidal_modifier(phase);
+                    }
+                    // Network tasks: moon governs data tides too
+                    TaskType::Network => {
+                        element_boost *= Self::moon_phase_flow_modifier(phase);
+                    }
+                    _ => {}
                 }
             }
         }
+
+        // ── Planetary aspects: boost or penalise based on cosmic alignments ───
+        let enable_aspects = self.enable_aspects;
+        let aspect_modifier = if enable_aspects {
+            let aspects = calculate_aspects(&positions);
+            combined_aspect_modifier(&aspects, ruling_planet)
+        } else {
+            1.0
+        };
+        element_boost *= aspect_modifier;
+
+        // ── Birth chart natal compatibility ───────────────────────────────────
+        let birth_modifier = self.birth_chart_modifier(pid, &positions, task_type);
+        element_boost *= birth_modifier;
 
         let base_priority = match task_type {
             TaskType::Critical => 1000,
@@ -175,6 +351,8 @@ impl AstrologicalScheduler {
             planet_pos,
             planetary_influence,
             element_boost,
+            aspect_modifier,
+            birth_modifier,
         );
 
         SchedulingDecision {
@@ -190,6 +368,8 @@ impl AstrologicalScheduler {
         planet_pos: &PlanetaryPosition,
         influence: f64,
         boost: f64,
+        aspect_modifier: f64,
+        birth_modifier: f64,
     ) -> String {
         let planet_name = planet_pos.planet.name();
         let sign_name = planet_pos.sign.name();
@@ -205,6 +385,28 @@ impl AstrologicalScheduler {
             );
         }
 
+        // Build aspect annotation
+        let aspect_note = if (aspect_modifier - 1.0).abs() > 0.05 {
+            if aspect_modifier > 1.0 {
+                format!(" | △ Aspects: +{:.0}%", (aspect_modifier - 1.0) * 100.0)
+            } else {
+                format!(" | □ Aspects: -{:.0}%", (1.0 - aspect_modifier) * 100.0)
+            }
+        } else {
+            String::new()
+        };
+
+        // Birth chart annotation
+        let natal_note = if (birth_modifier - 1.0).abs() > 0.05 {
+            if birth_modifier > 1.0 {
+                format!(" | 🌟 Natal: +{:.0}%", (birth_modifier - 1.0) * 100.0)
+            } else {
+                format!(" | ☁️ Natal: -{:.0}%", (1.0 - birth_modifier) * 100.0)
+            }
+        } else {
+            String::new()
+        };
+
         if boost < 0.7 {
             // DEBUFFED! Opposing elements clash
             let opposition = match (planet_pos.sign.element(), task_type) {
@@ -215,59 +417,61 @@ impl AstrologicalScheduler {
                 _ => "⚔️ Elemental opposition",
             };
             format!(
-                "⚠️ {} in {} ({}) | {} task DEBUFFED | {}",
-                planet_name,
-                sign_name,
-                element_name,
-                task_type.name(),
-                opposition
+                "⚠️ {} in {} ({}) | {} task DEBUFFED | {}{}{}",
+                planet_name, sign_name, element_name,
+                task_type.name(), opposition, aspect_note, natal_note
             )
         } else if boost > 1.3 {
-            // Strong positive influence
             format!(
-                "✨ {} in {} ({}) | {} task COSMICALLY BLESSED | {} provides divine boost",
-                planet_name,
-                sign_name,
-                element_name,
-                task_type.name(),
-                element_name
+                "✨ {} in {} ({}) | {} task COSMICALLY BLESSED | {} provides divine boost{}{}",
+                planet_name, sign_name, element_name,
+                task_type.name(), element_name, aspect_note, natal_note
             )
         } else if boost > 1.1 {
-            // Moderate positive influence
             format!(
-                "{} in {} | {} task enhanced by favorable {} energy",
-                planet_name,
-                sign_name,
-                task_type.name(),
-                element_name
+                "{} in {} | {} task enhanced by favorable {} energy{}{}",
+                planet_name, sign_name,
+                task_type.name(), element_name, aspect_note, natal_note
             )
         } else {
-            // Neutral
             format!(
-                "{} in {} | {} task neutral | Cosmos balanced",
-                planet_name,
-                sign_name,
-                task_type.name()
+                "{} in {} | {} task neutral | Cosmos balanced{}{}",
+                planet_name, sign_name,
+                task_type.name(), aspect_note, natal_note
             )
         }
+    }
+
+    /// Get a full system daily horoscope using the predictions module
+    pub fn get_daily_horoscope(&mut self, now: DateTime<Utc>) -> String {
+        let positions = self.get_planetary_positions(now).clone();
+        get_system_daily_horoscope(&positions, &now)
     }
 
     /// Get a summary of current astrological conditions
     pub fn get_cosmic_weather(&mut self, now: DateTime<Utc>) -> String {
         use std::fmt::Write;
 
+        // Capture flags before the positions borrow (can't access self fields
+        // while an &mut self borrow is alive via get_planetary_positions).
+        let use_13_signs = self.use_13_signs;
+        let enable_aspects = self.enable_aspects;
+        let enable_cpu_affinity = self.enable_cpu_affinity;
+
+        // Clone positions immediately so we own the data and there's no lingering
+        // &mut self borrow preventing later field access.
+        let positions: Vec<PlanetaryPosition> = self.get_planetary_positions(now).clone();
+
         let mut report = String::from("🌌 COSMIC WEATHER REPORT 🌌\n");
         let _ = writeln!(report, "Current time: {}", now.format("%Y-%m-%d %H:%M:%S UTC"));
-        if self.use_13_signs {
+        if use_13_signs {
             report.push_str("Zodiac system: 13-sign (IAU boundaries with Ophiuchus)\n");
         } else {
             report.push_str("Zodiac system: Traditional 12-sign (tropical)\n");
         }
         report.push('\n');
 
-        let positions = self.get_planetary_positions(now);
-
-        for pos in positions {
+        for pos in &positions {
             let phase_info = if let Some(phase) = pos.moon_phase {
                 format!(" [{}]", phase.name())
             } else {
@@ -369,6 +573,75 @@ impl AstrologicalScheduler {
 
         if !has_tensions {
             report.push_str("   ✌️  The elements are at peace (for now).\n");
+        }
+
+        // ── Planetary Aspects ──────────────────────────────────────────────────
+        if enable_aspects {
+            let aspects = calculate_aspects(&positions);
+            report.push_str("\n🔭 Planetary Aspects:\n");
+            if aspects.is_empty() {
+                report.push_str("   No major aspects active — planets orbit in splendid isolation.\n");
+            } else {
+                for asp in &aspects {
+                    let _ = writeln!(report,
+                        "   {} {} {} {} (orb: {:.1}°, strength: {:.0}%)",
+                        asp.planet_a.name(),
+                        asp.aspect_type.symbol(),
+                        asp.planet_b.name(),
+                        asp.aspect_type.name(),
+                        asp.orb,
+                        asp.strength * 100.0,
+                    );
+                }
+            }
+
+            // Show aspects for each ruling planet
+            report.push_str("\n   Aspect influences on task types:\n");
+            for &tt in &[TaskType::CpuIntensive, TaskType::Network, TaskType::MemoryHeavy, TaskType::System] {
+                let planet = tt.ruling_planet();
+                let modifier = combined_aspect_modifier(&aspects, planet);
+                let desc = describe_aspects(&aspects, planet);
+                let _ = writeln!(report, "   {} {}: {:.0}% — {}",
+                    tt.name(), planet.name(), modifier * 100.0, desc);
+            }
+        }
+
+        // ── Moon Phase Tidal Effects ────────────────────────────────────────────
+        if let Some(moon_pos) = positions.iter().find(|p| p.planet == Planet::Moon) {
+            if let Some(phase) = moon_pos.moon_phase {
+                report.push_str("\n🌊 Moon Phase Tidal Effects:\n");
+                let interactive_mod = Self::moon_phase_modifier(phase);
+                let memory_mod = Self::moon_phase_tidal_modifier(phase);
+                let network_mod = Self::moon_phase_flow_modifier(phase);
+                let _ = writeln!(report, "   Current phase: {} — {:+.0}% Interactive | {:+.0}% Memory | {:+.0}% Network",
+                    phase.name(),
+                    (interactive_mod - 1.0) * 100.0,
+                    (memory_mod - 1.0) * 100.0,
+                    (network_mod - 1.0) * 100.0,
+                );
+            }
+        }
+
+        // ── CPU Affinity Legend ────────────────────────────────────────────────
+        if enable_cpu_affinity {
+            report.push_str("\n🖥️  CPU Elemental Affinity (cycles every 4 CPUs):\n");
+            for (idx, (elem, sign)) in [
+                (Element::Fire,  element_sign(Element::Fire)),
+                (Element::Earth, element_sign(Element::Earth)),
+                (Element::Air,   element_sign(Element::Air)),
+                (Element::Water, element_sign(Element::Water)),
+            ].iter().enumerate() {
+                let _ = writeln!(report, "   CPU {},{},{}… → {} ({}) — best for {} tasks",
+                    idx, idx + 4, idx + 8,
+                    elem.name(), sign,
+                    match elem {
+                        Element::Fire  => "CPU-Intensive",
+                        Element::Earth => "System",
+                        Element::Air   => "Network",
+                        Element::Water => "Memory-Heavy",
+                    }
+                );
+            }
         }
 
         report

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,26 @@ struct Opts {
     /// By default, uses traditional 12-sign tropical zodiac
     #[clap(long)]
     ophiuchus: bool,
+
+    /// Enable natal birth chart per process (reads /proc/<pid>/stat creation time)
+    #[clap(long)]
+    birth_charts: bool,
+
+    /// Enable planetary aspect calculations (conjunctions, trines, oppositions, etc.)
+    #[clap(long)]
+    aspects: bool,
+
+    /// Show horoscope completion time predictions in debug output
+    #[clap(long)]
+    predictions: bool,
+
+    /// Enable per-CPU elemental affinity (Fire/Earth/Air/Water CPUs prefer matching tasks)
+    #[clap(long)]
+    cpu_affinity: bool,
+
+    /// Show the full system daily horoscope on startup (requires --cosmic-weather or -w)
+    #[clap(long)]
+    daily_horoscope: bool,
 }
 
 struct Scheduler<'a> {
@@ -90,7 +110,14 @@ impl<'a> Scheduler<'a> {
         )?;
 
         #[allow(clippy::cast_possible_wrap)]
-        let astro = AstrologicalScheduler::with_options(opts.update_interval as i64, opts.ophiuchus);
+        let astro = AstrologicalScheduler::with_full_options(
+            opts.update_interval as i64,
+            opts.ophiuchus,
+            opts.birth_charts,
+            opts.aspects,
+            opts.predictions,
+            opts.cpu_affinity,
+        );
         let last_update = Self::now();
 
         Ok(Self { bpf, astro, opts, last_update })
@@ -109,13 +136,20 @@ impl<'a> Scheduler<'a> {
         println!("\n{weather}\n");
     }
 
+    fn print_daily_horoscope(&mut self) {
+        let now = Utc::now();
+        let horoscope = self.astro.get_daily_horoscope(now);
+        println!("\n{horoscope}\n");
+    }
+
     fn dispatch_tasks(&mut self) {
         let now_chrono = Utc::now();
 
-        // Update planetary positions periodically
+        // Update planetary positions and evict stale birth charts periodically
         let current_time = Self::now();
         if current_time - self.last_update >= self.opts.update_interval {
             debug!("Updating planetary positions...");
+            self.astro.evict_dead_processes();
             self.last_update = current_time;
         }
 
@@ -136,9 +170,19 @@ impl<'a> Scheduler<'a> {
                     // Create dispatched task
                     let mut dispatched_task = DispatchedTask::new(&task);
 
-                    // Select CPU
+                    // Select CPU — optionally pick the most astrologically compatible one
                     let cpu = self.bpf.select_cpu(task.pid, task.cpu, task.flags);
                     dispatched_task.cpu = if cpu >= 0 { cpu } else { RL_CPU_ANY };
+
+                    // Per-CPU elemental affinity: log the cosmic compatibility score.
+                    if self.opts.cpu_affinity && self.opts.debug_decisions && dispatched_task.cpu != RL_CPU_ANY {
+                        let task_type = self.astro.classify_for_affinity(&comm);
+                        let snap = self.astro.current_positions(now_chrono);
+                        let score = self.astro.cpu_affinity_score(dispatched_task.cpu, task_type, &snap);
+                        if (score - 1.0).abs() > 0.01 {
+                            debug!("  🖥️  CPU {} affinity score for {}: {:.2}x", dispatched_task.cpu, task_type.name(), score);
+                        }
+                    }
 
                     // Calculate time slice based on priority
                     // Higher astrological priority = longer time slice
@@ -168,6 +212,18 @@ impl<'a> Scheduler<'a> {
                             decision.priority,
                             decision.reasoning
                         );
+
+                        // Horoscope prediction for this task type
+                        if self.opts.predictions {
+                            let task_type = self.astro.classify_for_affinity(&comm);
+                            let snap = self.astro.current_positions(now_chrono);
+                            if let Some(pred) = self.astro.horoscope_prediction(&snap, task_type, now_chrono) {
+                                debug!("  🔮 Forecast: {} | Power hour: {:02}:00 | Lucky: {}",
+                                    pred.completion_estimate.cosmic_reason,
+                                    pred.power_hour,
+                                    pred.lucky_number);
+                            }
+                        }
                     }
 
                     // Dispatch the task
@@ -212,12 +268,20 @@ impl<'a> Scheduler<'a> {
             self.print_cosmic_weather();
         }
 
+        if self.opts.daily_horoscope {
+            self.print_daily_horoscope();
+        }
+
         info!("Scheduler configuration:");
         info!("  Default time slice: {}μs", self.opts.slice_us);
         info!("  Min time slice: {}μs", self.opts.slice_us_min);
         info!("  Planetary update interval: {}s", self.opts.update_interval);
         info!("  Retrograde effects: {}", if self.opts.no_retrograde { "DISABLED" } else { "ENABLED" });
         info!("  Zodiac system: {}", if self.opts.ophiuchus { "13-sign (with Ophiuchus)" } else { "Traditional 12-sign" });
+        info!("  Birth charts: {}", if self.opts.birth_charts { "ENABLED" } else { "disabled" });
+        info!("  Planetary aspects: {}", if self.opts.aspects { "ENABLED" } else { "disabled" });
+        info!("  Completion predictions: {}", if self.opts.predictions { "ENABLED" } else { "disabled" });
+        info!("  CPU elemental affinity: {}", if self.opts.cpu_affinity { "ENABLED" } else { "disabled" });
 
         while !self.bpf.exited() {
             self.dispatch_tasks();


### PR DESCRIPTION
 Implements all five items from the Contributing section (atleast i tried):

- Add more planetary aspects (conjunctions, oppositions, trines)
- Add birth chart generation for processes (based on creation time)
- Horoscope predictions for task completion times
- Per-CPU affinity based on astrological compatibility
- Extend moon phase effects to other task types (I/O, memory operations)